### PR TITLE
Ignore service NEG annotations

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -22,5 +22,4 @@ locals {
 
   actual_resource_requests = merge(var.default_resource_requests, var.resource_requests)
   actual_resource_limits = merge(var.default_resource_limits, var.resource_limits)
-
 }

--- a/service.tf
+++ b/service.tf
@@ -9,7 +9,7 @@ resource "kubernetes_service" "memcached" {
     } : {}
 
     labels = {
-      "app.kubernetes.io/name" = local.instance_name
+      "app.kubernetes.io/name"    = local.instance_name
       "app.kubernetes.io/part-of" = "memcached"
     }
   }
@@ -30,7 +30,7 @@ resource "kubernetes_service" "memcached" {
     }
 
     selector = {
-      "app.kubernetes.io/name" = local.instance_name
+      "app.kubernetes.io/name"    = local.instance_name
       "app.kubernetes.io/part-of" = "memcached"
     }
   }

--- a/service.tf
+++ b/service.tf
@@ -3,6 +3,11 @@ resource "kubernetes_service" "memcached" {
     name      = local.instance_name
     namespace = var.namespace
 
+    annotations = var.gke_neg ? {
+      "cloud.google.com/neg-status" = ""                             # Eliminates Terraform diff
+      "cloud.google.com/neg"        = jsonencode({ ingress = true }) # Eliminates Terraform diff
+    } : {}
+
     labels = {
       "app.kubernetes.io/name" = local.instance_name
       "app.kubernetes.io/part-of" = "memcached"
@@ -28,6 +33,12 @@ resource "kubernetes_service" "memcached" {
       "app.kubernetes.io/name" = local.instance_name
       "app.kubernetes.io/part-of" = "memcached"
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations["cloud.google.com/neg-status"]
+    ]
   }
 }
 

--- a/stateful_set.tf
+++ b/stateful_set.tf
@@ -1,5 +1,6 @@
 resource "kubernetes_stateful_set" "memcached" {
   wait_for_rollout = false
+
   metadata {
     name = local.instance_name
 

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,11 @@ resource_limits = {
 EOF
   default = {}
 }
+
+variable "gke_neg" {
+  description =<<EOF
+Handle GKE NEG auto annotations.
+https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
+EOF
+  default = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
As was discussed in a side channel, eliminates the next diff:
```
  # module.wp-baggage.module.memcache.kubernetes_service.memcached will be updated in-place
  ~ resource "kubernetes_service" "memcached" {
        id                     = "seba/memcached-baggage-wp"
        # (2 unchanged attributes hidden)

      ~ metadata {
          ~ annotations      = {
              - "cloud.google.com/neg" = jsonencode(
                    {
                      - ingress = true
                    }
                ) -> null
            }
            name             = "memcached-baggage-wp"
            # (5 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }
```